### PR TITLE
Updated two features

### DIFF
--- a/fullShopifyBackup.sh
+++ b/fullShopifyBackup.sh
@@ -12,7 +12,7 @@ full=$(curl "https://$shopifyKey:$shopifyPassword@$storeName.myshopify.com/admin
 
 limit=250
 
-count=$((full / limit))
+count=$((full / limit+1))
 
 for page in $(seq 1 "$count");
   do

--- a/shopify.sh
+++ b/shopify.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 after=$(TZ='America/Denver' date +%FT%TZ)
-before=$(TZ='America/Denver' date +%FT%TZ -d "1 min ago")
+before=$(TZ='America/Denver' date +%FT%TZ -d "2 min ago")
 
 # Replace the xxxx with your own values.
 shopifyKey='xxxx'


### PR DESCRIPTION
Two updates here for better performance.

1. in `fullShopifyBackup.sh` I found that `count` doesn't round up when dividing. So for example if you had 595 orders, the count would be 2 instead of 2.318. To compensate for this, right now I"ll just add one to the count to get the left over orders.

2. in `shopify.sh` I found that when you're calling the API, it does like the time increments in one minute intervals. For example `&updated_at_min=2016-11-18T12:24:00Z&updated_at_max=2016-11-18T12:25:00Z` would return zero results, while  `&updated_at_min=2016-11-18T12:24:00Z&updated_at_max=2016-11-18T12:26:00Z` would return one or more results.